### PR TITLE
Actualizar la referencia a la versión de Python recomendada

### DIFF
--- a/01_introduccion/01_que_es_python.md
+++ b/01_introduccion/01_que_es_python.md
@@ -17,7 +17,7 @@ Aprovechamos de paso a darte la bienvenida a nuestro libro, un lugar donde podr�
 
 Dicho esto, empecemos. A diferencia de lo que mucha gente puede pensar, Python es un lenguaje que data de los años **1990s**, y su creación se le atribuye al neerlandés Guido van Rossum<sup><a href="https://es.wikipedia.org/wiki/Guido_van_Rossum" target="_blank" rel="noopener noreferrer">[1]</a></sup>. Recibió su nombre por los humoristas Monty Python.
 
-Su última versión es Python 3, y es la que te recomendamos usar ya que las anteriores ya tienen soporte oficial. En este blog usaremos esta siempre para todo.
+Su última versión es Python 3, y es la que te recomendamos usar ya que las anteriores ya no tienen soporte oficial. En este blog usaremos esta siempre para todo.
 
 De acuerdo con StackOverflow insights<sup><a href="https://insights.stackoverflow.com/trends" target="_blank" rel="noopener noreferrer">[2]</a></sup> en la siguiente gráfica podemos ver el número de preguntas vistas en la plataforma acerca de Pyhton. Podemos ver que Python lleva casi dos años en el podio, una auténtica burrada.
 


### PR DESCRIPTION
Se ha detectado un error en el texto que indica que las versiones anteriores de Python aún tienen soporte oficial. Esta información es incorrecta, ya que el soporte oficial para las versiones anteriores de Python ha finalizado. Para corregir este error, se ha agregado la línea "ya que las anteriores ya no tienen soporte oficial

**Cambio realizado:**
Se ha agregado la frase "ya que las anteriores ya no tienen soporte oficial" después de la mención de Python 3 como versión recomendada.